### PR TITLE
Adding more events features

### DIFF
--- a/lib/modules/bike_event.dart
+++ b/lib/modules/bike_event.dart
@@ -12,6 +12,8 @@ class BikeEvent {
   final DateTime createAt;
   final String name;
   final String? description;
+  final String? passcode;
+  bool private;
   final List<String> partecipants;
 
   BikeEvent(
@@ -22,6 +24,8 @@ class BikeEvent {
       required this.createAt,
       required this.name,
       required this.description,
+      required this.private,
+      this.passcode,
       required this.partecipants});
 
 
@@ -31,12 +35,14 @@ class BikeEvent {
   static void insertEvent(BikeEvent b) {
     FirebaseDatabase.instance.ref('events').push().set({
       'creatorName': b.creatorName,
+      'private': b.private,
       'creatorId': b.creatorId,
       'createdAt': b.createAt.millisecondsSinceEpoch,
       'route': b.bikeRouteName,
       'date': b.date.millisecondsSinceEpoch,
       'name': b.name,
       'description': b.description,
+      'passcode': b.passcode,
       'partecipants':{
         FirebaseAuth.instance.currentUser!.uid:DateTime.now().millisecondsSinceEpoch
       }
@@ -59,7 +65,7 @@ class BikeEvent {
         createAt: DateTime.fromMillisecondsSinceEpoch(data['createdAt']),
         name: data['name'] ?? 'name',
         partecipants: parts,
-        description: data['description'] ?? '');
+        description: data['description'] ?? '', private: data['private']??false, passcode: data['passcode']);
 
   }
 }

--- a/lib/screens/createevent.dart
+++ b/lib/screens/createevent.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:biketogether/modules/bike_event.dart';
 import 'package:biketogether/modules/bike_route.dart';
 import 'package:biketogether/screens/homepage.dart';
@@ -17,10 +19,13 @@ class _createEventState extends State<CreateEvent> {
   String _selectedPath = '';
   final _form = GlobalKey<FormState>();
   Map<String, dynamic> formFields = {};
+  bool privConfig = false;
   late DateTime first;
+
   ///Date controller
   final TextEditingController _dateController = TextEditingController();
   final TextEditingController _timeC = TextEditingController();
+
   @override
   void initState() {
     super.initState();
@@ -30,13 +35,14 @@ class _createEventState extends State<CreateEvent> {
   ///Time
   TimeOfDay timeOfDay = TimeOfDay.now();
 
-  Future displayTimePicker(BuildContext context) async{
+  Future displayTimePicker(BuildContext context) async {
     var time = await showTimePicker(context: context, initialTime: timeOfDay);
 
-    if(time != null){
+    if (time != null) {
       setState(() {
         _timeC.text = "${time.hour}:${time.minute}";
-        DateTime finalDate = DateTime(first.year, first.month, first.day, time.hour, time.minute);
+        DateTime finalDate = DateTime(
+            first.year, first.month, first.day, time.hour, time.minute);
         formFields.update('date', (value) => finalDate.millisecondsSinceEpoch,
             ifAbsent: () => finalDate.millisecondsSinceEpoch);
       });
@@ -170,50 +176,61 @@ class _createEventState extends State<CreateEvent> {
                   child: Padding(
                     padding: const EdgeInsets.only(left: 30, right: 30),
                     child: TextField(
-                      controller: _timeC,
-                      decoration: const InputDecoration(
-                        labelText: 'Orario Evento',
-                        filled: true,
-                        prefixIcon: Icon(Icons.alarm), //TODO find better icons
-                        enabledBorder:
-                        OutlineInputBorder(borderSide: BorderSide.none),
-                        focusedBorder: OutlineInputBorder(
-                          borderSide: BorderSide(color: Colors.blue),
+                        controller: _timeC,
+                        decoration: const InputDecoration(
+                          labelText: 'Orario Evento',
+                          filled: true,
+                          prefixIcon: Icon(Icons.alarm),
+                          //TODO find better icons
+                          enabledBorder:
+                              OutlineInputBorder(borderSide: BorderSide.none),
+                          focusedBorder: OutlineInputBorder(
+                            borderSide: BorderSide(color: Colors.blue),
+                          ),
                         ),
-                      ),
-                      readOnly: true,
-                      onTap: (){
-                        if(_dateController.text.isEmpty){
-                          showDialog<void>(
-                            context: context,
-                            barrierDismissible: false, // user must tap button!
-                            builder: (BuildContext context) {
-                              return AlertDialog(
-                                title: const Text('Errore'),
-                                content: const SingleChildScrollView(
-                                  child: ListBody(
-                                    children: <Widget>[
-                                      Text('Inserisci prima la data.'),
-                                    ],
+                        readOnly: true,
+                        onTap: () {
+                          if (_dateController.text.isEmpty) {
+                            showDialog<void>(
+                              context: context,
+                              barrierDismissible: false,
+                              // user must tap button!
+                              builder: (BuildContext context) {
+                                return AlertDialog(
+                                  title: const Text('Errore'),
+                                  content: const SingleChildScrollView(
+                                    child: ListBody(
+                                      children: <Widget>[
+                                        Text('Inserisci prima la data.'),
+                                      ],
+                                    ),
                                   ),
-                                ),
-                                actions: <Widget>[
-                                  TextButton(
-                                    child: const Text('Ok'),
-                                    onPressed: () {
-                                      Navigator.of(context).pop();
-                                    },
-                                  ),
-                                ],
-                              );
-                            },
-                          );
-                        }else {
-                          displayTimePicker(context);
-                        }
-                      }
-                    ),
+                                  actions: <Widget>[
+                                    TextButton(
+                                      child: const Text('Ok'),
+                                      onPressed: () {
+                                        Navigator.of(context).pop();
+                                      },
+                                    ),
+                                  ],
+                                );
+                              },
+                            );
+                          } else {
+                            displayTimePicker(context);
+                          }
+                        }),
                   ),
+                ),
+                Row(
+                  children: [
+                    Text('Evento privato'),
+                    Switch(
+                        splashRadius: 30.0,
+                        value: privConfig,
+                        onChanged: (value) =>
+                            setState(() => privConfig = value)),
+                  ],
                 ),
                 Padding(
                     padding: const EdgeInsets.symmetric(vertical: 16),
@@ -237,8 +254,11 @@ class _createEventState extends State<CreateEvent> {
                               creatorName: FirebaseAuth
                                   .instance.currentUser!.displayName
                                   .toString(),
+                              passcode: String.fromCharCodes(List.generate(
+                                  5, (index) => Random().nextInt(33) + 89)),
                               partecipants: [],
-                              description: formFields['desc'] ?? ''));
+                              description: formFields['desc'] ?? '',
+                              private: privConfig));
 
                           ScaffoldMessenger.of(context).showSnackBar(
                             const SnackBar(
@@ -246,9 +266,14 @@ class _createEventState extends State<CreateEvent> {
                                 content: Text(
                                     'Evento Creato')), // TODO check if event is created maybe and report success
                           );
-                          Navigator.push(context, MaterialPageRoute(builder: (context) => MyHomePage(title: 'Biketogether')) );
+                          Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (context) =>
+                                      MyHomePage(title: 'Biketogether')));
                         }
                       },
+
                       child: const Text(
                           'Submit'), // TODO switch to homepage after submit
                     ))

--- a/lib/screens/event.dart
+++ b/lib/screens/event.dart
@@ -8,6 +8,7 @@ import 'package:biketogether/screens/homepage.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class EventPage extends StatefulWidget {
   const EventPage({super.key, required this.eventname});
@@ -51,13 +52,13 @@ class _EventPageState extends State<EventPage> {
                               .contains(FirebaseAuth.instance.currentUser!.uid))
                           ? IconButton(
                               onPressed: () {
-                                FirebaseDatabase.instance
-                                    .ref('/events/$eventID/')
-                                    .child('partecipants')
-                                    .update({
-                                  FirebaseAuth.instance.currentUser!.uid:
-                                      DateTime.now().millisecondsSinceEpoch
-                                });
+                                  FirebaseDatabase.instance
+                                      .ref('/events/$eventID/')
+                                      .child('partecipants')
+                                      .update({
+                                    FirebaseAuth.instance.currentUser!.uid:
+                                        DateTime.now().millisecondsSinceEpoch
+                                  });
                               },
                               icon: const Icon(Icons.add))
                           : Row(
@@ -192,10 +193,13 @@ class _EventPageState extends State<EventPage> {
                                                           actions: [
                                                             ElevatedButton(
                                                               onPressed: () {
-
-                                                                ScaffoldMessenger.of(context).showSnackBar(
+                                                                ScaffoldMessenger.of(
+                                                                        context)
+                                                                    .showSnackBar(
                                                                   const SnackBar(
-                                                                      backgroundColor: Colors.green,
+                                                                      backgroundColor:
+                                                                          Colors
+                                                                              .green,
                                                                       content: Text(
                                                                           'Evento eliminato')),
                                                                 );
@@ -212,9 +216,10 @@ class _EventPageState extends State<EventPage> {
                                                                     .remove();
                                                               },
                                                               child: const Text(
-                                                                  'Elimina',style: TextStyle(
-                                                                  color:
-                                                                  Colors.white)),
+                                                                  'Elimina',
+                                                                  style: TextStyle(
+                                                                      color: Colors
+                                                                          .white)),
                                                               style: ButtonStyle(
                                                                   backgroundColor:
                                                                       MaterialStateProperty.all(
@@ -225,7 +230,8 @@ class _EventPageState extends State<EventPage> {
                                                         );
                                                       });
                                                 },
-                                              )
+                                              ),
+
                                             ])
                               ],
                             )
@@ -285,6 +291,17 @@ class _EventPageState extends State<EventPage> {
                       //   'creato da ${event.creatorName} il ${event.createAt.toString().substring(0, 10)}',
                       //   style: const TextStyle(fontSize: 20),
                       // ),
+                      event.private?ElevatedButton(onPressed: (){
+                        Clipboard.setData(ClipboardData(text: event.passcode??'Errore codice evento'));
+                      }, child: Row(
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Text('Codice Evento: ${event.passcode}',textScaleFactor: 1.35,),
+                          ),
+                          Icon(Icons.copy)
+                        ],
+                      )):Container(),
                       const Padding(padding: EdgeInsets.only(bottom: 20.0)),
                       const Divider(),
                       FutureBuilder(
@@ -293,7 +310,7 @@ class _EventPageState extends State<EventPage> {
                               .child('routes/${event.bikeRouteName}')
                               .once(),
                           builder: (context, snapshot) {
-                            if (snapshot.hasData ) {
+                            if (snapshot.hasData) {
                               final route = BikeRoute.fromDB(
                                   Map<String, dynamic>.from(
                                       snapshot.data!.snapshot.value as Map));

--- a/lib/screens/event.dart
+++ b/lib/screens/event.dart
@@ -34,7 +34,7 @@ class _EventPageState extends State<EventPage> {
         stream:
             FirebaseDatabase.instance.ref().child('events/$eventID').onValue,
         builder: (context, snapshot) {
-          if (snapshot.hasData) {
+          if (snapshot.hasData && snapshot.data!.snapshot.value != null) {
             final event = BikeEvent.fromDB(Map<String, dynamic>.from(
                 snapshot.data!.snapshot.value as Map));
             return Scaffold(
@@ -68,7 +68,7 @@ class _EventPageState extends State<EventPage> {
                                           context,
                                           MaterialPageRoute(
                                               builder: (context) =>
-                                                  ChatPage()));
+                                                  const ChatPage()));
                                     },
                                     icon: const Icon(Icons.chat)),
                                 (event.creatorId !=
@@ -79,8 +79,8 @@ class _EventPageState extends State<EventPage> {
                                               context: context,
                                               builder: (context) {
                                                 return AlertDialog(
-                                                  title:
-                                                      Text('Abbandona evento'),
+                                                  title: const Text(
+                                                      'Abbandona evento'),
                                                   content: Text(
                                                       'vuoi abbandonare l\'evento "${event.name}"?'),
                                                   actions: [
@@ -90,7 +90,8 @@ class _EventPageState extends State<EventPage> {
                                                             .instance
                                                             .ref()
                                                             .child(
-                                                                '/events/$eventID/partecipants/${FirebaseAuth.instance.currentUser!.uid}').remove();
+                                                                '/events/$eventID/partecipants/${FirebaseAuth.instance.currentUser!.uid}')
+                                                            .remove();
                                                         Navigator.of(context)
                                                             .pop();
                                                       },
@@ -114,7 +115,7 @@ class _EventPageState extends State<EventPage> {
                                     : PopupMenuButton(
                                         itemBuilder: (context) => [
                                               PopupMenuItem(
-                                                child: Text('Modifica'),
+                                                child: const Text('Modifica'),
                                                 onTap: () {
                                                   showDialog<void>(
                                                       context: context,
@@ -173,6 +174,58 @@ class _EventPageState extends State<EventPage> {
                                                       });
                                                 },
                                               ),
+                                              PopupMenuItem(
+                                                child: const Text(
+                                                  'Elimina',
+                                                  style: TextStyle(
+                                                      color: Colors.red),
+                                                ),
+                                                onTap: () {
+                                                  showDialog(
+                                                      context: context,
+                                                      builder: (context) {
+                                                        return AlertDialog(
+                                                          title: const Text(
+                                                              'Eliminazione evento'),
+                                                          content: Text(
+                                                              'vuoi eliminare l\'evento:\n${event.name}?'),
+                                                          actions: [
+                                                            ElevatedButton(
+                                                              onPressed: () {
+
+                                                                ScaffoldMessenger.of(context).showSnackBar(
+                                                                  const SnackBar(
+                                                                      backgroundColor: Colors.green,
+                                                                      content: Text(
+                                                                          'Evento eliminato')),
+                                                                );
+                                                                Navigator.pushReplacement(
+                                                                    context,
+                                                                    MaterialPageRoute(
+                                                                        builder:
+                                                                            (context) =>
+                                                                                const MyHomePage(title: 'Biketogether')));
+                                                                FirebaseDatabase
+                                                                    .instance
+                                                                    .ref(
+                                                                        'events/$eventID')
+                                                                    .remove();
+                                                              },
+                                                              child: const Text(
+                                                                  'Elimina',style: TextStyle(
+                                                                  color:
+                                                                  Colors.white)),
+                                                              style: ButtonStyle(
+                                                                  backgroundColor:
+                                                                      MaterialStateProperty.all(
+                                                                          Colors
+                                                                              .redAccent)),
+                                                            )
+                                                          ],
+                                                        );
+                                                      });
+                                                },
+                                              )
                                             ])
                               ],
                             )
@@ -240,7 +293,7 @@ class _EventPageState extends State<EventPage> {
                               .child('routes/${event.bikeRouteName}')
                               .once(),
                           builder: (context, snapshot) {
-                            if (snapshot.hasData) {
+                            if (snapshot.hasData ) {
                               final route = BikeRoute.fromDB(
                                   Map<String, dynamic>.from(
                                       snapshot.data!.snapshot.value as Map));

--- a/lib/screens/homepage.dart
+++ b/lib/screens/homepage.dart
@@ -51,13 +51,25 @@ class _MyHomePageState extends State<MyHomePage> {
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         // Here we take the value from the MyHomePage object that was created by
         // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
+        title: Text('Eventi pubblici'),
       ),
       body: Column(
         children: [
-          const Text(
-            'Eventi Pubblici',
-            style: TextStyle(fontSize: 25, fontWeight: FontWeight.bold),
+          Padding(
+            padding: const EdgeInsets.only(left: 8.0, right: 8.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  'Esami passati?',
+                  style: TextStyle(fontSize: 20),
+                ),
+                Switch(
+                    splashRadius: 30.0,
+                    value: showOld,
+                    onChanged: (value) => setState(() => showOld = value)),
+              ],
+            ),
           ),
           Padding(
             padding: const EdgeInsets.all(8.0),
@@ -72,15 +84,6 @@ class _MyHomePageState extends State<MyHomePage> {
                   searchedEventname = e;
                   setState(() {});
                 }),
-          ),
-          Row(
-            children: [
-              Text('Eventi passati'),
-              Switch(
-                  splashRadius: 30.0,
-                  value: showOld,
-                  onChanged: (value) => setState(() => showOld = value)),
-            ],
           ),
           StreamBuilder(
             builder: (context, snapshot) {

--- a/lib/screens/homepage.dart
+++ b/lib/screens/homepage.dart
@@ -23,6 +23,7 @@ class MyHomePage extends StatefulWidget {
   // always marked "final".
 
   final String title;
+
   @override
   State<MyHomePage> createState() => _MyHomePageState();
 }
@@ -30,6 +31,7 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   String searchedEventname = '';
   bool showOld = false;
+
   @override
   void initState() {}
 
@@ -54,32 +56,32 @@ class _MyHomePageState extends State<MyHomePage> {
       body: Column(
         children: [
           const Text(
-            'Eventi Pubblici',style: TextStyle(
-              fontSize: 25,
-              fontWeight: FontWeight.bold
-          ),),
+            'Eventi Pubblici',
+            style: TextStyle(fontSize: 25, fontWeight: FontWeight.bold),
+          ),
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: TextField(
                 decoration: const InputDecoration(
-                  enabledBorder: OutlineInputBorder(
-                    borderSide: BorderSide(
-                        width: 1, color: Colors.black45),
-                  ),
-                    labelText: 'Ricerca Evento', suffixIcon: Icon(Icons.search)),
+                    enabledBorder: OutlineInputBorder(
+                      borderSide: BorderSide(width: 1, color: Colors.black45),
+                    ),
+                    labelText: 'Ricerca Evento',
+                    suffixIcon: Icon(Icons.search)),
                 onChanged: (e) {
                   searchedEventname = e;
                   setState(() {});
                 }),
           ),
-           Row(
-             children: [
-               Text('Eventi passati'),
-               Switch(
-                   splashRadius: 30.0,value: showOld, onChanged: (value)=>setState(() => showOld=value )),
-             ],
-           ),
-           // TODO fare lista apparte o sopra con eventi a cui sono già iscritto
+          Row(
+            children: [
+              Text('Eventi passati'),
+              Switch(
+                  splashRadius: 30.0,
+                  value: showOld,
+                  onChanged: (value) => setState(() => showOld = value)),
+            ],
+          ),
           StreamBuilder(
             builder: (context, snapshot) {
               final cardList = <Card>[];
@@ -90,9 +92,16 @@ class _MyHomePageState extends State<MyHomePage> {
                 final allEvents = Map<String, dynamic>.from(
                     snapshot.data!.snapshot.value as Map);
                 cardList.addAll(allEvents.entries
-                    .where((element) => element.value['name']
-                        .toString().toLowerCase()
-                        .contains(searchedEventname.toLowerCase()) && (DateTime.fromMillisecondsSinceEpoch(element.value['date']).isAfter(DateTime.now()) || showOld))
+                    .where((element) =>
+                        element.value['name']
+                            .toString()
+                            .toLowerCase()
+                            .contains(searchedEventname.toLowerCase()) &&
+                        (!DateTime.fromMillisecondsSinceEpoch(
+                                    element.value['date'])
+                                .isBefore(DateTime.now()) ||
+                            showOld) &&
+                        !(element.value['private'] as bool))
                     .map((e) {
                   final event =
                       BikeEvent.fromDB(Map<String, dynamic>.from(e.value));

--- a/lib/screens/homepage.dart
+++ b/lib/screens/homepage.dart
@@ -6,6 +6,7 @@ import 'package:biketogether/screens/personalevents.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../main.dart';
 import 'login.dart';
@@ -61,6 +62,9 @@ class _MyHomePageState extends State<MyHomePage> {
               builder: (context) => AlertDialog(
                 title: const Text('Codice Evento'),
                 content: TextField(
+                  inputFormatters: [
+                    LengthLimitingTextInputFormatter(5)
+                  ],
                   decoration: const InputDecoration(
                     hintText:'Inserisci il codice di 5 lettere'
                   ),

--- a/lib/screens/homepage.dart
+++ b/lib/screens/homepage.dart
@@ -51,7 +51,62 @@ class _MyHomePageState extends State<MyHomePage> {
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         // Here we take the value from the MyHomePage object that was created by
         // the App.build method, and use it to set our appbar title.
-        title: Text('Eventi pubblici'),
+        title: const Text('Eventi pubblici'),
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: const Icon(Icons.lock_open_outlined),
+        onPressed: () {
+          showDialog(
+              context: context,
+              builder: (context) => AlertDialog(
+                title: const Text('Codice Evento'),
+                content: TextField(
+                  decoration: const InputDecoration(
+                    hintText:'Inserisci il codice di 5 lettere'
+                  ),
+                  onSubmitted: (value) {
+                    FirebaseDatabase.instance
+                        .ref()
+                        .child('events')
+                        .orderByChild('passcode')
+                        .equalTo(value)
+                        .get()
+                        .then((value) {
+                      if (!value.exists) {
+                        Navigator.of(context).pop();
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                              backgroundColor: Colors.red,
+                              content: Text(
+                                  'Codice invalido')),
+                        );
+                      } else {
+                        try{
+                        FirebaseDatabase.instance
+                            .ref(
+                            'events/${value.children.first.key}/partecipants')
+                            .update({
+                          FirebaseAuth.instance.currentUser!.uid:
+                          DateTime.now().millisecondsSinceEpoch
+                        });
+                        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                          backgroundColor: Colors.green,
+                          content: Text("Partecipazione effettuata"),
+                        ));
+
+                        ;} catch(e){
+                          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                            backgroundColor: Colors.redAccent,
+                            content: Text("Errore"),
+                          ));
+                        }
+                        Navigator.of(context).pop();
+                      }
+                    });
+                  },
+                ),
+              ));
+        },
       ),
       body: Column(
         children: [
@@ -162,7 +217,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       Navigator.push(
                           context,
                           MaterialPageRoute(
-                              builder: (context) => CreateEvent()));
+                              builder: (context) => const CreateEvent()));
                     },
                   ),
                   ListTile(
@@ -172,7 +227,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       Navigator.push(
                           context,
                           MaterialPageRoute(
-                              builder: (context) => MyEventsPage()));
+                              builder: (context) => const MyEventsPage()));
                     },
                   )
                 ],

--- a/lib/screens/homepage.dart
+++ b/lib/screens/homepage.dart
@@ -29,7 +29,7 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   String searchedEventname = '';
-
+  bool showOld = false;
   @override
   void initState() {}
 
@@ -72,6 +72,13 @@ class _MyHomePageState extends State<MyHomePage> {
                   setState(() {});
                 }),
           ),
+           Row(
+             children: [
+               Text('Eventi passati'),
+               Switch(
+                   splashRadius: 30.0,value: showOld, onChanged: (value)=>setState(() => showOld=value )),
+             ],
+           ),
            // TODO fare lista apparte o sopra con eventi a cui sono già iscritto
           StreamBuilder(
             builder: (context, snapshot) {
@@ -85,7 +92,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 cardList.addAll(allEvents.entries
                     .where((element) => element.value['name']
                         .toString().toLowerCase()
-                        .contains(searchedEventname.toLowerCase()))
+                        .contains(searchedEventname.toLowerCase()) && (DateTime.fromMillisecondsSinceEpoch(element.value['date']).isAfter(DateTime.now()) || showOld))
                     .map((e) {
                   final event =
                       BikeEvent.fromDB(Map<String, dynamic>.from(e.value));

--- a/lib/screens/personalevents.dart
+++ b/lib/screens/personalevents.dart
@@ -21,46 +21,6 @@ class _MyEventsPageState extends State<MyEventsPage> {
           backgroundColor: Theme.of(context).colorScheme.inversePrimary,
           title: const Text('I Miei Eventi'),
         ),
-        floatingActionButton: FloatingActionButton(
-          child: Icon(Icons.lock_open_outlined),
-          onPressed: () {
-            showDialog(
-                context: context,
-                builder: (context) => AlertDialog(
-                      title: Text('Codice Evento'),
-                      content: TextField(
-                        onSubmitted: (value) {
-                          FirebaseDatabase.instance
-                              .ref()
-                              .child('events')
-                              .orderByChild('passcode')
-                              .equalTo(value)
-                              .get()
-                              .then((value) {
-                                print(value);
-                            if (!value.exists) {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(
-                                    backgroundColor: Colors.red,
-                                    content: Text(
-                                        'Codice invalido')),
-                              );
-                            } else {
-                              FirebaseDatabase.instance
-                                  .ref(
-                                      'events/${value.children.first.key}/partecipants')
-                                  .update({
-                                FirebaseAuth.instance.currentUser!.uid:
-                                    DateTime.now().millisecondsSinceEpoch
-                              });
-                              Navigator.of(context).pop();
-                            }
-                          });
-                        },
-                      ),
-                    ));
-          },
-        ),
         body: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [


### PR DESCRIPTION
Added the following features regarding any events

- ﻿toggle past events in homepage: now only events whose starting date is in the past are hidden, in oder to view the full list of present and past events you can press the switch button

- delete event button for creators: creators can delete their event by the 3-dot menu (previous confirmation), located in the event page
- private events: upon creating any event the user can select to set it private so it will not be shown under public events. The passcode to enter an event is shown in the event page and to enter an event you need to write its passocode in `I Miei Eventi`

